### PR TITLE
Terrarium encoding instead of mapbox encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ const gsiTerrainSource: RasterDEMSourceSpecification = {
     tileSize: 256,
     minzoom: 1,
     maxzoom: 17,
+    encoding: 'terrarium',
     attribution:
     '<a href="https://maps.gsi.go.jp/development/ichiran.html">地理院タイル</a>',
 };

--- a/example/index.ts
+++ b/example/index.ts
@@ -8,6 +8,7 @@ const gsiTerrainSource: RasterDEMSourceSpecification = {
 	type: 'raster-dem',
 	tiles: ['gsidem://https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png'],
 	tileSize: 256,
+	encoding: 'terrarium',
 	minzoom: 1,
 	maxzoom: 17,
 	attribution:

--- a/src/terrain.ts
+++ b/src/terrain.ts
@@ -141,6 +141,7 @@ export const useGsiTerrainSource = (
 		type: 'raster-dem',
 		tiles: [`gsidem://${tileUrl}`],
 		tileSize: 256,
+		encoding: 'terrarium',
 		minzoom: options.minzoom ?? 1,
 		maxzoom: options.maxzoom ?? 14,
 		attribution:

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -25,22 +25,28 @@ const fsSource = \`#version 300 es
         vec4 color = texture(u_height_map, v_tex_coord);
         vec3 rgb = color.rgb * 255.0;
 
-        // terrainRGBにおける高度0の色
-        vec4 zero_elevation_color = vec4(1.0, 134.0, 160.0, 255.0) / 255.0;
-
-        float rgb_value = dot(rgb, vec3(65536.0, 256.0, 1.0));
-        float height = mix(rgb_value, rgb_value - 16777216.0, step(8388608.0, rgb_value)) * 0.01;
-        height = (height + 10000.0) * 10.0;
+        // terrariumにおける高度0の色
+        vec4 zero_elevation_color = vec4(128.0, 0.0, 0.0, 255.0) / 255.0;
 
         // 地理院標高タイルの無効値または完全に透明なピクセルの判定
         bool is_valid = (rgb.r != 128.0 || rgb.g != 0.0 || rgb.b != 0.0) && color.a != 0.0;
 
+        float rgb_value = dot(rgb, vec3(65536.0, 256.0, 1.0));
+        float height = mix(rgb_value, rgb_value - 16777216.0, step(8388608.0, rgb_value)) * 0.01;
+
+        // terrariumの標高値エンコード
+        height += 32768.0;
+        float r = floor(height / 256.0);
+        float g = floor(mod(height, 256.0));
+        float b = floor((height - floor(height)) * 256.0);
+
+        // terrariumの標高値を色に変換
         fragColor = mix(
             zero_elevation_color,
             vec4(
-                floor(height / 65536.0) / 255.0,
-                floor(mod(height / 256.0, 256.0)) / 255.0,
-                mod(height, 256.0) / 255.0,
+                r / 255.0,
+                g / 255.0,
+                b / 255.0,
                 1.0
             ),
             float(is_valid)


### PR DESCRIPTION
- Mapbox encoding(default)よりもTerrarium encodingの方が精度が高いのでTerrarium encodingを採用したものを実装してみた