### PR TITLE
Inline terrain worker to fix module usage

### DIFF
--- a/src/terrain.ts
+++ b/src/terrain.ts
@@ -3,7 +3,7 @@ import type {
 	RasterDEMSourceSpecification,
 } from 'maplibre-gl';
 import maplibregl from 'maplibre-gl';
-import TerrainWorker from './terrain.worker.ts?worker';
+import TerrainWorker from './terrain.worker.ts?worker&inline';
 
 let worker: Worker | null = null;
 let requestId = 0;


### PR DESCRIPTION
## Changes
- Change terrain worker import from `?worker` to `?worker&inline`

## Reason
- Without `inline`, the worker is built as a separate file with an absolute/relative path
- When this library is used as a module in other projects, the worker file path cannot be resolved
- Inlining the worker code as a Blob solves this path resolution issue

## Impact
- The library can now be properly used as an npm module
- No functional changes to the worker behavior